### PR TITLE
[feat] 요즘 뜨는 셀러 TOP6 구현

### DIFF
--- a/src/main/java/yteamserver/YteamServerApplication.java
+++ b/src/main/java/yteamserver/YteamServerApplication.java
@@ -2,8 +2,10 @@ package yteamserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class YteamServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/yteamserver/domain/store/application/StoreService.java
+++ b/src/main/java/yteamserver/domain/store/application/StoreService.java
@@ -1,0 +1,34 @@
+package yteamserver.domain.store.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yteamserver.domain.store.domain.Store;
+import yteamserver.domain.store.domain.repository.StoreRepository;
+import yteamserver.domain.store.dto.GetTopStoresRes;
+import yteamserver.domain.store.dto.TopStoreRes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+    private final StoreRepository storeRepository;
+
+
+    public GetTopStoresRes getTopStore() {
+        // 비디오 테이블 참조하여 조회수 상위 6개 업체 조회
+        List<Store> stores = storeRepository.findAllByViewCount();
+        List<TopStoreRes> topStoreResList = new ArrayList<>();
+
+        for (Store store : stores) {
+            topStoreResList.add(TopStoreRes.builder()
+                    .storeName(store.getStoreName())
+                    .imgUrl(store.getImgUrl())
+                    .hashtags(store.getHashtags())
+                    .build());
+        }
+
+        return new GetTopStoresRes(topStoreResList);
+    }
+}

--- a/src/main/java/yteamserver/domain/store/domain/repository/StoreRepository.java
+++ b/src/main/java/yteamserver/domain/store/domain/repository/StoreRepository.java
@@ -11,6 +11,10 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
     Optional<Store> findByStoreName(String storeName);
 
-    @Query(value = "SELECT * FROM store s INNER JOIN video v on s.id = v.store_id ORDER BY v.view_count DESC LIMIT 6", nativeQuery = true)
+    @Query(value = "SELECT s.* FROM store s\n" +
+            "JOIN ( \n" +
+            "    SELECT v.store_id FROM video v ORDER BY v.view_count DESC LIMIT 6\n" +
+            ") AS top_stores\n" +
+            "ON s.id = top_stores.store_id", nativeQuery = true)
     List<Store> findAllByViewCount();
 }

--- a/src/main/java/yteamserver/domain/store/domain/repository/StoreRepository.java
+++ b/src/main/java/yteamserver/domain/store/domain/repository/StoreRepository.java
@@ -13,8 +13,8 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
     @Query(value = "SELECT s.* FROM store s\n" +
             "JOIN ( \n" +
-            "    SELECT v.store_id FROM video v ORDER BY v.view_count DESC LIMIT 6\n" +
+            "    SELECT DISTINCT v.store_id FROM video v ORDER BY v.view_count DESC\n" +
             ") AS top_stores\n" +
-            "ON s.id = top_stores.store_id", nativeQuery = true)
+            "ON s.id = top_stores.store_id LIMIT 6", nativeQuery = true)
     List<Store> findAllByViewCount();
 }

--- a/src/main/java/yteamserver/domain/store/domain/repository/StoreRepository.java
+++ b/src/main/java/yteamserver/domain/store/domain/repository/StoreRepository.java
@@ -1,11 +1,16 @@
 package yteamserver.domain.store.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import yteamserver.domain.store.domain.Store;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
     Optional<Store> findByStoreName(String storeName);
+
+    @Query(value = "SELECT * FROM store s INNER JOIN video v on s.id = v.store_id ORDER BY v.view_count DESC LIMIT 6", nativeQuery = true)
+    List<Store> findAllByViewCount();
 }

--- a/src/main/java/yteamserver/domain/store/dto/GetTopStoresRes.java
+++ b/src/main/java/yteamserver/domain/store/dto/GetTopStoresRes.java
@@ -1,0 +1,16 @@
+package yteamserver.domain.store.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GetTopStoresRes {
+    private List<TopStoreRes> sellers;
+
+    @Builder
+    public GetTopStoresRes(List<TopStoreRes> sellers) {
+        this.sellers = sellers;
+    }
+}

--- a/src/main/java/yteamserver/domain/store/dto/TopStoreRes.java
+++ b/src/main/java/yteamserver/domain/store/dto/TopStoreRes.java
@@ -2,7 +2,6 @@ package yteamserver.domain.store.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import yteamserver.domain.store.domain.Store;
 
 import java.util.List;
 
@@ -16,6 +15,11 @@ public class TopStoreRes {
     public TopStoreRes(String storeName, String imgUrl, String hashtags) {
         this.storeName = storeName;
         this.imgUrl = imgUrl;
+
+        if(hashtags == null) {
+           return;
+        }
+
         String[] hashtagList = hashtags.split("#");
 
         for (String hashtag : hashtagList) {

--- a/src/main/java/yteamserver/domain/store/dto/TopStoreRes.java
+++ b/src/main/java/yteamserver/domain/store/dto/TopStoreRes.java
@@ -22,8 +22,6 @@ public class TopStoreRes {
 
         String[] hashtagList = hashtags.split("#");
 
-        for (String hashtag : hashtagList) {
-            this.hashtags.add(hashtag);
-        }
+        this.hashtags = List.of(hashtagList);
     }
 }

--- a/src/main/java/yteamserver/domain/store/dto/TopStoreRes.java
+++ b/src/main/java/yteamserver/domain/store/dto/TopStoreRes.java
@@ -1,0 +1,25 @@
+package yteamserver.domain.store.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import yteamserver.domain.store.domain.Store;
+
+import java.util.List;
+
+@Getter
+public class TopStoreRes {
+    private String storeName;
+    private String imgUrl;
+    private List<String> hashtags;
+
+    @Builder
+    public TopStoreRes(String storeName, String imgUrl, String hashtags) {
+        this.storeName = storeName;
+        this.imgUrl = imgUrl;
+        String[] hashtagList = hashtags.split("#");
+
+        for (String hashtag : hashtagList) {
+            this.hashtags.add(hashtag);
+        }
+    }
+}

--- a/src/main/java/yteamserver/domain/store/presentation/StoreController.java
+++ b/src/main/java/yteamserver/domain/store/presentation/StoreController.java
@@ -1,0 +1,31 @@
+package yteamserver.domain.store.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yteamserver.domain.store.application.StoreService;
+import yteamserver.domain.video.dto.CreateVideoReq;
+import yteamserver.global.response.Response;
+
+@Tag(name = "Store", description = "Store API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stores")
+public class StoreController {
+    private final StoreService storeService;
+
+    @Operation(summary = "요즘 뜨는 셀러 TOP6", description = "메인 화면에서 숏폼 영상 조회수 상위 6개의 업체를 조회합니다.")
+    @GetMapping("/top")
+    public ResponseEntity<Response> getTopStore() {
+        return Response.of(HttpStatus.OK, storeService.getTopStore());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- [x] Video 테이블 참조하여 숏폼 조회수 TOP6 (중복 제거) 업체 불러오기
- [x] 각 업체별 업체명, 업체 로고 이미지, 좋아요 수, 관련 해시태그 정보 DTO로 구성하기

## 스크린샷
<img width="1551" alt="스크린샷 2024-06-01 오후 9 21 05" src="https://github.com/Ne-o-rdinary-Hackathon-Yteam/yteam-server/assets/90602694/84168a1c-bdb6-4d02-a359-f757461ba15a">

- Closes #6